### PR TITLE
Correctly convert quantifier {,y} to {0,y}

### DIFF
--- a/js_regex.gemspec
+++ b/js_regex.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'character_set', '~> 1.4'
-  s.add_dependency 'regexp_parser', '~> 2.1'
+  s.add_dependency 'regexp_parser', '~> 2.4'
   s.add_dependency 'regexp_property_values', '~> 1.0'
 end

--- a/lib/js_regex/converter/base.rb
+++ b/lib/js_regex/converter/base.rb
@@ -35,7 +35,7 @@ class JsRegex
           node.update(quantifier: qtf.text[0..-2])
           return wrap_in_backrefed_lookahead(node)
         elsif qtf.token == :interval && qtf.text[0..1] == "{,"
-          qtf.text = "{#{qtf.min},#{qtf.max}}"
+          qtf.text = "{0,#{qtf.max}}"
           node.update(quantifier: qtf)
         else
           node.update(quantifier: qtf)

--- a/lib/js_regex/converter/base.rb
+++ b/lib/js_regex/converter/base.rb
@@ -34,6 +34,9 @@ class JsRegex
         if qtf.possessive?
           node.update(quantifier: qtf.text[0..-2])
           return wrap_in_backrefed_lookahead(node)
+        elsif qtf.token == :interval && qtf.text[0..1] == "{,"
+          qtf.text = "{#{qtf.min},#{qtf.max}}"
+          node.update(quantifier: qtf)
         else
           node.update(quantifier: qtf)
         end

--- a/spec/lib/js_regex/converter/base_spec.rb
+++ b/spec/lib/js_regex/converter/base_spec.rb
@@ -62,6 +62,10 @@ describe JsRegex::Converter::Base do
         expect(/a{6,8}/).to stay_the_same
       end
 
+      it 'converts an implicit min value of 0 to an explicit one ({,y})' do
+        expect(/a{,8}/).to become(/a{0,8}/)
+      end
+
       it 'preserves set quantifiers' do
         expect(/[a-z]{6,8}/).to stay_the_same
       end


### PR DESCRIPTION
Fixes https://github.com/jaynetics/js_regex/issues/14

In Ruby the quantifier `{,y}` matches 0 to y occurrences but in Javascript `{,y}` is interpreted as a literal, the correct translation is `{0,y}`.

I also changed the dependencies to depend on regexp_parser ~> 2.4 since previous versions don't have `Regexp::Expression::Quantifier#text=`

I'll be more than happy to receive suggestions on how to improve this PR.