### PR TITLE
Enable Frozen String Literals

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,11 @@ jobs:
       matrix:
         ruby: [ '3.1', '3.2', '3.3', '3.4', 'ruby-head' ]
 
+    env:
+      # The RUBYOPT flags can be removed if RuboCop style checks are added
+      # to the lint workflow and support for Ruby < 2.3 is dropped.
+      RUBYOPT: '--enable=frozen-string-literal --debug=frozen-string-literal'
+
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
@@ -21,4 +26,4 @@ jobs:
       - name: Test with Rake
         run: bundle exec rake
       - uses: codecov/codecov-action@v3
-        if: matrix.ruby == '3.4' # match version in spec_helper.rb:1
+        if: matrix.ruby == '3.4' # match version in spec_helper.rb:3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- enable frozen string literals (#42)
+
 ## [3.13.0] - 2025-01-27
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in js_regex.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Dir['tasks/**/*.rake'].each { |file| load(file) }
 
 require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'js_regex'

--- a/js_regex.gemspec
+++ b/js_regex.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 dir = File.expand_path(__dir__)
 require File.join(dir, 'lib', 'js_regex', 'version')
 

--- a/lib/js_regex.rb
+++ b/lib/js_regex.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # JsRegex converts ::Regexp instances to JavaScript.
 #
 # Usage:

--- a/lib/js_regex/conversion.rb
+++ b/lib/js_regex/conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   #
   # This class acts as a facade, passing a Regexp to the Converters.

--- a/lib/js_regex/converter.rb
+++ b/lib/js_regex/converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   module Converter
     Dir[File.join(__dir__, 'converter', '*.rb')].sort.each do |file|

--- a/lib/js_regex/converter/anchor_converter.rb
+++ b/lib/js_regex/converter/anchor_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/assertion_converter.rb
+++ b/lib/js_regex/converter/assertion_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 require_relative 'group_converter'
 

--- a/lib/js_regex/converter/backreference_converter.rb
+++ b/lib/js_regex/converter/backreference_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/base.rb
+++ b/lib/js_regex/converter/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   module Converter
     #

--- a/lib/js_regex/converter/conditional_converter.rb
+++ b/lib/js_regex/converter/conditional_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/context.rb
+++ b/lib/js_regex/converter/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   module Converter
     #

--- a/lib/js_regex/converter/escape_converter.rb
+++ b/lib/js_regex/converter/escape_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 require_relative 'literal_converter'
 

--- a/lib/js_regex/converter/freespace_converter.rb
+++ b/lib/js_regex/converter/freespace_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/group_converter.rb
+++ b/lib/js_regex/converter/group_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/keep_converter.rb
+++ b/lib/js_regex/converter/keep_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/literal_converter.rb
+++ b/lib/js_regex/converter/literal_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex
@@ -6,8 +8,8 @@ class JsRegex
     # Template class implementation.
     #
     class LiteralConverter < JsRegex::Converter::Base
-      ASTRAL_PLANE_CODEPOINT_PATTERN = /[\u{10000}-\u{10FFFF}]/
-      LITERAL_REQUIRING_ESCAPE_PATTERN = /[\/\f\n\r\t\v]/
+      ASTRAL_PLANE_CODEPOINT_PATTERN = /[\u{10000}-\u{10FFFF}]/.freeze
+      LITERAL_REQUIRING_ESCAPE_PATTERN = /[\/\f\n\r\t\v]/.freeze
 
       class << self
         def convert_data(data, context)
@@ -59,7 +61,7 @@ class JsRegex
         result
       end
 
-      HAS_CASE_PATTERN = /[\p{lower}\p{upper}]/
+      HAS_CASE_PATTERN = /[\p{lower}\p{upper}]/.freeze
 
       def handle_locally_case_insensitive_literal(literal)
         literal =~ HAS_CASE_PATTERN ? case_insensitivize(literal) : literal

--- a/lib/js_regex/converter/meta_converter.rb
+++ b/lib/js_regex/converter/meta_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/property_converter.rb
+++ b/lib/js_regex/converter/property_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 require 'character_set'
 

--- a/lib/js_regex/converter/set_converter.rb
+++ b/lib/js_regex/converter/set_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 require_relative 'escape_converter'
 require_relative 'type_converter'
@@ -76,7 +78,7 @@ class JsRegex
       end
 
       SET_LITERALS_REQUIRING_ESCAPE_PATTERN = Regexp.union(%w<( ) [ ] { } / - |>)
-      SET_SPECIFIC_ESCAPES_PATTERN = /[\^\-]/
+      SET_SPECIFIC_ESCAPES_PATTERN = /[\^\-]/.freeze
       CONVERTIBLE_ESCAPE_TOKENS = %i[control meta_sequence bell escape octal] +
         EscapeConverter::ESCAPES_SHARED_BY_RUBY_AND_JS
 

--- a/lib/js_regex/converter/subexpression_converter.rb
+++ b/lib/js_regex/converter/subexpression_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/type_converter.rb
+++ b/lib/js_regex/converter/type_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/converter/unsupported_token_converter.rb
+++ b/lib/js_regex/converter/unsupported_token_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'base'
 
 class JsRegex

--- a/lib/js_regex/error.rb
+++ b/lib/js_regex/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   # This is mixed into errors, e.g. those thrown by the parser,
   # allowing to `rescue JsRegex::Error`.

--- a/lib/js_regex/node.rb
+++ b/lib/js_regex/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   #
   # Converter#convert result. Represents a branch or leaf node with an optional

--- a/lib/js_regex/second_pass.rb
+++ b/lib/js_regex/second_pass.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   #
   # After conversion of a full Regexp::Expression tree, this

--- a/lib/js_regex/target.rb
+++ b/lib/js_regex/target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   module Target
     ES2009 = 'ES2009'

--- a/lib/js_regex/version.rb
+++ b/lib/js_regex/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class JsRegex
   VERSION = '3.13.0'
 end

--- a/spec/acceptance_spec.rb
+++ b/spec/acceptance_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'uri'
 

--- a/spec/lib/js_regex/conversion_spec.rb
+++ b/spec/lib/js_regex/conversion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Conversion do

--- a/spec/lib/js_regex/converter/anchor_converter_spec.rb
+++ b/spec/lib/js_regex/converter/anchor_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::AnchorConverter do

--- a/spec/lib/js_regex/converter/assertion_converter_spec.rb
+++ b/spec/lib/js_regex/converter/assertion_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::AssertionConverter do

--- a/spec/lib/js_regex/converter/backreference_converter_spec.rb
+++ b/spec/lib/js_regex/converter/backreference_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::BackreferenceConverter do

--- a/spec/lib/js_regex/converter/base_spec.rb
+++ b/spec/lib/js_regex/converter/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::Base do

--- a/spec/lib/js_regex/converter/conditional_converter_spec.rb
+++ b/spec/lib/js_regex/converter/conditional_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::ConditionalConverter do

--- a/spec/lib/js_regex/converter/context_spec.rb
+++ b/spec/lib/js_regex/converter/context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::Context do

--- a/spec/lib/js_regex/converter/escape_converter_spec.rb
+++ b/spec/lib/js_regex/converter/escape_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 #
 #
@@ -141,17 +143,17 @@ describe JsRegex::Converter::EscapeConverter do
   end
 
   it 'converts control sequences to unicode escapes' do
-    expect(Regexp.new('\C-*'.force_encoding('ascii-8bit'))).to\
+    expect(Regexp.new('\C-*'.dup.force_encoding('ascii-8bit'))).to\
     become(/\u000A/).and keep_matching("ya\ny", with_results: %W[\n])
   end
 
   it 'converts meta sequences to unicode escapes' do
-    expect(Regexp.new('\M-X'.force_encoding('ascii-8bit'))).to\
+    expect(Regexp.new('\M-X'.dup.force_encoding('ascii-8bit'))).to\
     become(/\u00D8/)
   end
 
   it 'converts meta control sequences to unicode escapes' do
-    expect(Regexp.new('\M-\C-X'.force_encoding('ascii-8bit'))).to\
+    expect(Regexp.new('\M-\C-X'.dup.force_encoding('ascii-8bit'))).to\
     become(/\u0098/)
   end
 

--- a/spec/lib/js_regex/converter/freespace_converter_spec.rb
+++ b/spec/lib/js_regex/converter/freespace_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 #
 #

--- a/spec/lib/js_regex/converter/group_converter_spec.rb
+++ b/spec/lib/js_regex/converter/group_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::GroupConverter do

--- a/spec/lib/js_regex/converter/keep_converter_spec.rb
+++ b/spec/lib/js_regex/converter/keep_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::KeepConverter do

--- a/spec/lib/js_regex/converter/literal_converter_spec.rb
+++ b/spec/lib/js_regex/converter/literal_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 #
 #

--- a/spec/lib/js_regex/converter/meta_converter_spec.rb
+++ b/spec/lib/js_regex/converter/meta_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::MetaConverter do

--- a/spec/lib/js_regex/converter/property_converter_spec.rb
+++ b/spec/lib/js_regex/converter/property_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::PropertyConverter do

--- a/spec/lib/js_regex/converter/set_converter_spec.rb
+++ b/spec/lib/js_regex/converter/set_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::SetConverter do

--- a/spec/lib/js_regex/converter/type_converter_spec.rb
+++ b/spec/lib/js_regex/converter/type_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::TypeConverter do

--- a/spec/lib/js_regex/converter/unsupported_token_converter_spec.rb
+++ b/spec/lib/js_regex/converter/unsupported_token_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Converter::UnsupportedTokenConverter do

--- a/spec/lib/js_regex/second_pass_spec.rb
+++ b/spec/lib/js_regex/second_pass_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::SecondPass do

--- a/spec/lib/js_regex/target_spec.rb
+++ b/spec/lib/js_regex/target_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex::Target do

--- a/spec/lib/js_regex_spec.rb
+++ b/spec/lib/js_regex_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe JsRegex do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['CI'] && RUBY_VERSION.start_with?('3.4') # match version in tests.yml
   require 'simplecov'
   require 'simplecov-cobertura'

--- a/tasks/build_prop_map.rake
+++ b/tasks/build_prop_map.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc <<-TXT
   Finds Unicode properties supported by both Ruby and ES2018+, filters out those
   that match the same character set in both languages, and writes a file mapping


### PR DESCRIPTION
Add `frozen_string_literal` magic comment to enable frozen string
literals for Ruby versions that support it to prepare the library
for Ruby 4, ensuring all specs pass and referencing community guidance.

This change reduces allocations on Ruby 2.3 and newer, and despite
initial concerns, benchmarks during testing show no evidence of
regression.

Since the library still supports Ruby versions earlier than 2.3 and
potential issues cannot be ruled out for those versions, the CI workflow
now sets

```
RUBYOPT='--enable=frozen-string-literal --debug=frozen-string-literal'
```

to help prevent future regressions.

Code has been automatically fixed by RuboCop by temporarily change
target version to 2.3 and running:

```
be rubocop --only Style/FrozenStringLiteralComment,Layout/EmptyLineAfterMagicComment,Style/RedundantFreeze,Style/MutableConstant -A lib/**/*.rb
```

Close #41