### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/gouteur.yml
+++ b/.github/workflows/gouteur.yml
@@ -11,13 +11,11 @@ jobs:
       - name: Set up Node                        # for client_side_validations js test
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3
+          ruby-version: 3.4
           bundler-cache: true
-      - name: Prepare
-        run: bundle install --jobs 4
       - name: Test
         run: bundle exec gouteur

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3
+        ruby-version: 3.4
     - name: Cache gems
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', 'ruby-head' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', 'ruby-head' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,11 +16,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install dependencies
-        run: |
-          gem update --system # https://github.com/rubyjs/mini_racer/issues/289
-          bundle install --jobs 4
+          bundler-cache: true
+          rubygems: latest
       - name: Test with Rake
         run: bundle exec rake
       - uses: codecov/codecov-action@v3
-        if: matrix.ruby == '3.3' # match version in spec_helper.rb:1
+        if: matrix.ruby == '3.4' # match version in spec_helper.rb:1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,12 +6,16 @@ AllCops:
   RubyInterpreters:
     - ruby
     - rake
-  TargetRubyVersion: 2.6 # really 2.1, but 2.6 is lowest supported by rubocop
+  TargetRubyVersion: 2.1
 
 # disable some non-linty lint cops, these are more like style checks
 Lint/AmbiguousOperatorPrecedence:
   Enabled: false
 Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+# TODO: temporarily disabled because of new offenses reported on CI
+Lint/UselessConstantScoping:
   Enabled: false
 
 # ignore weird looking regexps in specs, we wanna keep those

--- a/js_regex.gemspec
+++ b/js_regex.gemspec
@@ -1,4 +1,3 @@
-# encoding: utf-8
 dir = File.expand_path(__dir__)
 require File.join(dir, 'lib', 'js_regex', 'version')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-if ENV['CI'] && RUBY_VERSION.start_with?('3.3') # match version in tests.yml
+if ENV['CI'] && RUBY_VERSION.start_with?('3.4') # match version in tests.yml
   require 'simplecov'
   require 'simplecov-cobertura'
   SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter

--- a/tasks/build_prop_map.rake
+++ b/tasks/build_prop_map.rake
@@ -1,4 +1,4 @@
-desc <<~TXT
+desc <<-TXT
   Finds Unicode properties supported by both Ruby and ES2018+, filters out those
   that match the same character set in both languages, and writes a file mapping
   normalized, Ruby-compatible property names to ES-compatible property names.


### PR DESCRIPTION
- Test against Ruby 3.4
- Update Ruby 3.3 to 3.4
- Update Node 18 to 22
- Update RuboCop action/cache to v4 to prevent failure
- Use `rubygems: latest` option instead of manually updating bundler
- Use `rubygems: latest` option instead of manually updating bundler

Additionally:
- Make `build_prop_make` compatible with Ruby 2.1 and 2.2, by removing
  the squiggly heredoc (introduced in Ruby >= 2.3). The previous
  implementation was raising a Syntax Error during RuboCop analysis
- Set RuboCop TargetRubyVersion to 2.1, which is supported since
  RuboCop 1.30 (https://github.com/rubocop/rubocop/pull/10662)
- Disable a new offense `Lint/UselessConstantScoping` which was causing
  the CI to fail
- Remove unnecessary utf-8 encoding comment in gemspec, since it is the
  default encoding starting from Ruby 2.0

---

Passing CI: https://github.com/tagliala/js_regex/pull/1