### PR TITLE
Align RuboCop config with regexp_parser

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,16 +14,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.4
-    - name: Cache gems
-      uses: actions/cache@v4
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run rubocop
-      run: bundle exec rubocop --lint
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,17 @@
 AllCops:
+  DisabledByDefault: true
   Exclude:
-    - '**/vendor/**/*' # vendored dependencies
-    - './tmp/**/*'
+    - '.git/**/*'
+    - '{bin,pkg,tmp,vendor}/**/*' # vendored dependencies etc.
   NewCops: enable
   RubyInterpreters:
     - ruby
     - rake
+  SuggestExtensions: false
   TargetRubyVersion: 2.1
+
+Lint:
+  Enabled: true
 
 # disable some non-linty lint cops, these are more like style checks
 Lint/AmbiguousOperatorPrecedence:


### PR DESCRIPTION
- Only enable the `Lint` department, allowing `bundle exec rubocop` to pass
- Exclude `.git`: when a custom `Exclude` is provided, default config is not being inherited (ref: rubocop/rubocop#9325)
- Do not suggest extensions
- Use built-in cache